### PR TITLE
Allow override of `ES_JAVA_OPTS` (#787)

### DIFF
--- a/localstack/services/es/es_starter.py
+++ b/localstack/services/es/es_starter.py
@@ -31,7 +31,7 @@ def start_elasticsearch(port=PORT_ELASTICSEARCH, delete_data=True, async=False, 
         es_data_dir = '%s/elasticsearch' % DATA_DIR
     # Elasticsearch 5.x cannot be bound to 0.0.0.0 in some Docker environments,
     # hence we use the default bind address 127.0.0.0 and put a proxy in front of it
-    cmd = (('ES_JAVA_OPTS=\"$ES_JAVA_OPTS -Xms200m -Xmx500m\" ES_TMPDIR="%s" ' +
+    cmd = (('ES_JAVA_OPTS=\"${ES_JAVA_OPTS:--Xms200m -Xmx500m}\" ES_TMPDIR="%s" ' +
         '%s/infra/elasticsearch/bin/elasticsearch ' +
         '-E http.port=%s -E http.publish_port=%s -E http.compression=false -E path.data=%s') %
         (es_tmp_dir, ROOT_PATH, backend_port, backend_port, es_data_dir))


### PR DESCRIPTION
The `ES_JAVA_OPTS` were being set, but not allowing the user to override
specific settings (`-Xms` and `-Xmx`).

This simply adds syntax necessary to allow a user to completely override
the contents of `ES_JAVA_OPTS`, with a fallback to the existing ones.

**Please refer to the contribution guidelines in the README when submitting PRs.**
